### PR TITLE
Selective icon update

### DIFF
--- a/app.py
+++ b/app.py
@@ -182,6 +182,7 @@ class PingBarApp(App):
                 )
                 self.statistics_menu.title = "Paused"
                 self._icon_nsimage = symbol_icon("pause.circle", "Paused")
+                self._nsapp.setStatusBarIcon()
             else:
                 logger.debug(
                     f"In refresh_status(): Application is running, showing latency and loss"
@@ -207,7 +208,7 @@ class PingBarApp(App):
                     
                 logger.debug(f"In refresh_status(): Last state: {self._last_state}, new state: {new_state}")
                 self._last_state = new_state
-                
+
                 if icon:
                     logger.debug(f"In refresh_status(): Updating icon for new state: {new_state}")
                     self._icon_nsimage = icon

--- a/app.py
+++ b/app.py
@@ -63,6 +63,7 @@ class PingBarApp(App):
         self.pause_menu.state = self.get_setting("paused", False)
         self.menu = [self.statistics_menu, self.pause_menu, self.display_menu]
         self._changed = False
+        self._last_state = None
 
         self.pinger = Pinger(
             targets=self.settings.get("targets", []),
@@ -195,7 +196,12 @@ class PingBarApp(App):
 
                 match display:
                     case "Dot":
-                        self._icon_nsimage = status_dot_icon(self.latency, self.loss)
+                        icon, new_state = status_dot_icon(self.latency, self.loss, self._last_state)
+                        logger.debug(f"In refresh_status(): Last state: {self._last_state}, new state: {new_state}")
+                        self._last_state = new_state
+                        if icon:
+                            logger.debug(f"In refresh_status(): Updating icon for new state: {new_state}")
+                            self._icon_nsimage = icon
                     case "Text":
                         self._icon_nsimage = status_text_icon(self.latency, self.loss)
                     case _:

--- a/app.py
+++ b/app.py
@@ -208,7 +208,7 @@ class PingBarApp(App):
                 logger.debug(f"In refresh_status(): Last state: {self._last_state}, new state: {new_state}")
                 self._last_state = new_state
                 
-                if icon:
+                if icon is not None:
                     logger.debug(f"In refresh_status(): Updating icon for new state: {new_state}")
                     self._icon_nsimage = icon
                     self._nsapp.setStatusBarIcon()

--- a/app.py
+++ b/app.py
@@ -197,19 +197,21 @@ class PingBarApp(App):
                 match display:
                     case "Dot":
                         icon, new_state = status_dot_icon(self.latency, self.loss, self._last_state)
-                        logger.debug(f"In refresh_status(): Last state: {self._last_state}, new state: {new_state}")
-                        self._last_state = new_state
-                        if icon:
-                            logger.debug(f"In refresh_status(): Updating icon for new state: {new_state}")
-                            self._icon_nsimage = icon
+                        
                     case "Text":
-                        self._icon_nsimage = status_text_icon(self.latency, self.loss)
+                        icon, new_state = status_text_icon(self.latency, self.loss, self._last_state)
                     case _:
                         raise ValueError(
                             f"Invalid display_mode setting: {self.settings.get('display_mode')}"
                         )
-
-            self._nsapp.setStatusBarIcon()
+                    
+                logger.debug(f"In refresh_status(): Last state: {self._last_state}, new state: {new_state}")
+                self._last_state = new_state
+                
+                if icon:
+                    logger.debug(f"In refresh_status(): Updating icon for new state: {new_state}")
+                    self._icon_nsimage = icon
+                    self._nsapp.setStatusBarIcon()
 
     @clicked("Ping targets")
     def ping_targets(self, _):

--- a/app.py
+++ b/app.py
@@ -197,20 +197,28 @@ class PingBarApp(App):
 
                 match display:
                     case "Dot":
-                        icon, new_state = status_dot_icon(self.latency, self.loss, self._last_state)
-                        
+                        icon, new_state = status_dot_icon(
+                            self.latency, self.loss, self._last_state
+                        )
+
                     case "Text":
-                        icon, new_state = status_text_icon(self.latency, self.loss, self._last_state)
+                        icon, new_state = status_text_icon(
+                            self.latency, self.loss, self._last_state
+                        )
                     case _:
                         raise ValueError(
                             f"Invalid display_mode setting: {self.settings.get('display_mode')}"
                         )
-                    
-                logger.debug(f"In refresh_status(): Last state: {self._last_state}, new state: {new_state}")
+
+                logger.debug(
+                    f"In refresh_status(): Last state: {self._last_state}, new state: {new_state}"
+                )
                 self._last_state = new_state
-                
+
                 if icon is not None:
-                    logger.debug(f"In refresh_status(): Updating icon for new state: {new_state}")
+                    logger.debug(
+                        f"In refresh_status(): Updating icon for new state: {new_state}"
+                    )
                     self._icon_nsimage = icon
                     self._nsapp.setStatusBarIcon()
 

--- a/icon.py
+++ b/icon.py
@@ -17,18 +17,20 @@ from AppKit import (
     NSImageSymbolConfiguration,
 )
 from Foundation import NSUserDefaults
+from typing import Tuple
 
 
 def status_dot_icon(
     latency: float | None,
     loss: float | None,
+    last_state: str | None = None,
     latency_warn_threshold: float = 80.0,
     latency_alert_threshold: float = 500.0,
     latency_critical_threshold: float = 1000.0,
     loss_warn_threshold: float = 0.00,
     loss_alert_threshold: float = 0.05,
     loss_critical_threshold: float = 0.25,
-) -> NSImage:
+) -> Tuple[NSImage | None, str]:
     """Create a status dot icon based on latency and loss thresholds.
 
     This function generates a small NSImage icon (20x20 pixels) that displays
@@ -39,6 +41,7 @@ def status_dot_icon(
     Args:
         latency (float | None): Network latency in milliseconds, or None if unavailable.
         loss (float | None): Packet loss as a decimal (0.0-1.0), or None if unavailable.
+        last_state (str | None): The previous state of the network status ("normal", "warn", "alert", "critical", or "unknown"). Used to determine if the icon needs to be updated. Defaults to None.
         latency_warn_threshold (float): Warning threshold for latency in ms. Defaults to 80.0.
         latency_alert_threshold (float): Alert threshold for latency in ms. Defaults to 500.0.
         latency_critical_threshold (float): Critical threshold for latency in ms. Defaults to 1000.0.
@@ -47,7 +50,9 @@ def status_dot_icon(
         loss_critical_threshold (float): Critical threshold for loss as decimal. Defaults to 0.25.
 
     Returns:
-        NSImage: A 20x20 pixel icon with a colored dot representing network status.
+        Tuple[NSImage | None, str]: A tuple with a 20x20 pixel icon with a colored dot representing network status, or None
+        if the new state equals the previous state, and a string describing the current state.
+
     """
 
     symbol_name = "circle.fill"
@@ -56,19 +61,26 @@ def status_dot_icon(
         case (la, lo) if la is None or lo is None:
             symbol_name = "circle.dotted"
             color = None
+            state = "unknown"
         case (la, lo) if (
             la > latency_critical_threshold or lo > loss_critical_threshold
         ):
             color = NSColor.redColor()
+            state = "critical"
         case (la, lo) if la > latency_alert_threshold or lo > loss_alert_threshold:
             color = NSColor.orangeColor()
+            state = "alert"
         case (la, lo) if la > latency_warn_threshold or lo > loss_warn_threshold:
             color = NSColor.yellowColor()
+            state = "warn"
         case _:
             color = None
+            state = "normal"
 
-    return symbol_icon(symbol_name, "Network Status", color, True)
-
+    if state == last_state:
+        return None, state
+    
+    return (symbol_icon(symbol_name, "Network Status", color, True), state)
 
 def status_text_icon(
     latency: float | None,

--- a/icon.py
+++ b/icon.py
@@ -116,7 +116,9 @@ def status_text_icon(
         if the new state equals the previous state, and a string describing the current state.
     """
 
-    new_state = f'{latency:{".1f" if latency else ""}}-{loss:{".1f" if loss else ""}}'
+    latency_text = f"{latency:.1f}" if latency is not None else "---"
+    loss_text = f"{loss * 100:.1f} %" if loss is not None else "---"
+    new_state = f"{latency_text}-{loss_text}"
     if new_state == last_state:
         return None, new_state
 

--- a/icon.py
+++ b/icon.py
@@ -79,8 +79,9 @@ def status_dot_icon(
 
     if state == last_state:
         return None, state
-    
+
     return (symbol_icon(symbol_name, "Network Status", color, True), state)
+
 
 def status_text_icon(
     latency: float | None,
@@ -195,7 +196,7 @@ def status_text_icon(
         )
 
     image.unlockFocus()
-    return image, new_state 
+    return image, new_state
 
 
 def symbol_icon(

--- a/icon.py
+++ b/icon.py
@@ -85,13 +85,14 @@ def status_dot_icon(
 def status_text_icon(
     latency: float | None,
     loss: float | None,
+    last_state: str | None = None,
     latency_warn_threshold: float = 80.0,
     latency_alert_threshold: float = 500.0,
     latency_critical_threshold: float = 1000.0,
     loss_warn_threshold: float = 0.00,
     loss_alert_threshold: float = 0.05,
     loss_critical_threshold: float = 0.25,
-):
+) -> Tuple[NSImage | None, str]:
     """Create a status text icon showing latency and loss with color-coded thresholds.
 
     This function generates a two-line NSImage icon displaying network latency
@@ -102,6 +103,7 @@ def status_text_icon(
     Args:
         latency (float | None): Network latency in milliseconds, or None if unavailable.
         loss (float | None): Packet loss as a decimal (0.0-1.0), or None if unavailable.
+        last_state (str | None): The previous state of the network status (concatenation of latency and loss states). Used to determine if the icon needs to be updated. Defaults to None.
         latency_warn_threshold (float): Warning threshold for latency in ms. Defaults to 80.0.
         latency_alert_threshold (float): Alert threshold for latency in ms. Defaults to 500.0.
         latency_critical_threshold (float): Critical threshold for latency in ms. Defaults to 1000.0.
@@ -110,8 +112,13 @@ def status_text_icon(
         loss_critical_threshold (float): Critical threshold for loss as decimal. Defaults to 0.25.
 
     Returns:
-        NSImage: A 50x20 pixel icon with right-aligned text showing latency and loss values.
+        Tuple[NSImage | None, str]: A tuple with a 50x20 pixel icon with right-aligned text showing latency and loss values, or None
+        if the new state equals the previous state, and a string describing the current state.
     """
+
+    new_state = f'{latency:{".1f" if latency else ""}}-{loss:{".1f" if loss else ""}}'
+    if new_state == last_state:
+        return None, new_state
 
     size = NSSize(50, 20)
 
@@ -186,7 +193,7 @@ def status_text_icon(
         )
 
     image.unlockFocus()
-    return image
+    return image, new_state 
 
 
 def symbol_icon(

--- a/icon.py
+++ b/icon.py
@@ -117,7 +117,7 @@ def status_text_icon(
     """
 
     latency_text = f"{latency:.1f}" if latency is not None else "---"
-    loss_text = f"{loss * 100:.1f} %" if loss is not None else "---"
+    loss_text = f"{loss * 100:.1f}" if loss is not None else "---"
     new_state = f"{latency_text}-{loss_text}"
     if new_state == last_state:
         return None, new_state


### PR DESCRIPTION
Currently, a new icon is generated with every ping result, even if the icon wouldn't change. This PR updates both icon generators to take a "last_state" parameter, which is a string representation of the previous generated icon. If the new icon would be identical to the previous icon, None is returned instead of an icon. 

refresh_status() is updated to send the last state string received, and to only initiate an icon refresh if a new icon was returned by the icon generator