### PR TITLE
Fix updating latency when latency is None

### DIFF
--- a/pingrthingr/app.py
+++ b/pingrthingr/app.py
@@ -163,10 +163,8 @@ class PingrThingrApp(App):
             f"In update_statistics(): Updating statistics: loss={self.loss}, latency={self.latency}"
         )
 
-        if latency is not None:
-            self.latency = latency
-        if loss is not None:
-            self.loss = loss
+        self.latency = latency
+        self.loss = loss
 
         self._changed = True
 

--- a/pingrthingr/app.py
+++ b/pingrthingr/app.py
@@ -185,9 +185,9 @@ class PingrThingrApp(App):
                 logger.debug(
                     f"In refresh_status(): Application is running, showing latency and loss"
                 )
-                loss_str = f"{(self.loss*100):.2f}%" if self.loss is not None else "N/A"
+                loss_str = f"{(self.loss*100):.2f}%" if self.loss is not None else "---"
                 latency_str = (
-                    f"{(self.latency):.2f} ms" if self.latency is not None else "N/A"
+                    f"{(self.latency):.2f} ms" if self.latency is not None else "---"
                 )
                 self.statistics_menu.title = f"Loss: {loss_str}, Latency: {latency_str}"
                 display = self.settings.get("display_mode", "Dot")

--- a/pingrthingr/app.py
+++ b/pingrthingr/app.py
@@ -149,7 +149,7 @@ class PingrThingrApp(App):
         self._changed = True
         self.refresh_status(self)
 
-    def update_statistics(self, latency: float = None, loss: float = None):
+    def update_statistics(self, latency: float | None = None, loss: float | None = None):
         """Update the statistics display with new network measurements.
 
         Called by the pinger when new latency and packet loss measurements

--- a/pingrthingr/icons/icon.py
+++ b/pingrthingr/icons/icon.py
@@ -58,19 +58,23 @@ def status_dot_icon(
     symbol_name = "circle.fill"
 
     match (latency, loss):
-        case (la, lo) if la is None or lo is None:
+        case (la, lo) if lo is None:
             symbol_name = "circle.dotted"
             color = None
             state = "unknown"
         case (la, lo) if (
-            la > latency_critical_threshold or lo > loss_critical_threshold
-        ):
+            la or 0.0
+        ) > latency_critical_threshold or lo > loss_critical_threshold:
             color = NSColor.redColor()
             state = "critical"
-        case (la, lo) if la > latency_alert_threshold or lo > loss_alert_threshold:
+        case (la, lo) if (
+            la or 0.0
+        ) > latency_alert_threshold or lo > loss_alert_threshold:
             color = NSColor.orangeColor()
             state = "alert"
-        case (la, lo) if la > latency_warn_threshold or lo > loss_warn_threshold:
+        case (la, lo) if (
+            la or 0.0
+        ) > latency_warn_threshold or lo > loss_warn_threshold:
             color = NSColor.yellowColor()
             state = "warn"
         case _:


### PR DESCRIPTION
Improved outlier rejection now generates a latency of "None" if all targets are down. Fix update_statistics to accept None as a value, and update refresh_status and status_dot_icon to properly handle None states