### PR TITLE
Implement on-demand display refresh

### DIFF
--- a/pingrthingr/app.py
+++ b/pingrthingr/app.py
@@ -13,6 +13,8 @@ from json import dump as json_dump, load as json_load
 from .pinger import Pinger
 from .icons import status_text_icon, status_dot_icon, symbol_icon
 from .settings import SelectableMenu, update_ping_targets
+from objc import selector as objc_selector
+from Foundation import NSOperationQueue, NSBlockOperation
 
 
 class PingrThingrApp(App):
@@ -62,7 +64,7 @@ class PingrThingrApp(App):
         )
         self.pause_menu.state = self.get_setting("paused", False)
         self.menu = [self.statistics_menu, self.pause_menu, self.display_menu]
-        self._changed = False
+        # self._changed = False
         self._last_state = None
 
         self.pinger = Pinger(
@@ -147,78 +149,83 @@ class PingrThingrApp(App):
         logger.debug(f"In set_display_mode(): Setting display_mode to {mode}")
         self.set_setting("display_mode", mode)
         self._changed = True
-        self.refresh_status(self)
+        self.refresh_status_(use_saved=True)
 
-    def update_statistics(self, latency: float | None = None, loss: float | None = None):
+    def update_statistics(self, latency: float | None = None, loss: float | None = None) -> None:
         """Update the statistics display with new network measurements.
 
         Called by the pinger when new latency and packet loss measurements
-        are available. Updates internal state and triggers a menu refresh.
+        are available. Updates internal state and triggers a display refresh.
 
         Args:
             latency (float, optional): The average latency in milliseconds. Defaults to None.
             loss (float, optional): The packet loss as a decimal (0.0-1.0). Defaults to None.
         """
+        
         logger.debug(
-            f"In update_statistics(): Updating statistics: loss={self.loss}, latency={self.latency}"
+            f"In update_statistics(): Updating statistics: loss={loss}, latency={latency}"
         )
 
-        self.latency = latency
-        self.loss = loss
+        operation = NSBlockOperation.blockOperationWithBlock_(lambda: self.refresh_status_(latency, loss))
+        NSOperationQueue.mainQueue().addOperation_(operation)
 
-        self._changed = True
-
-    @timer(1)
-    def refresh_status(self, _):
+    @objc_selector
+    def refresh_status_(self, latency: float | None = None, loss: float | None = None, use_saved: bool = False):
         """Refresh the status display and menu item text every second."""
+        print(f"Refreshing status: latency={latency}, loss={loss}, use_saved={use_saved}")
 
-        if self._changed:
-            self._changed = False
-            if self.settings.get("paused"):
-                logger.debug(
-                    f"In refresh_status(): Application is paused, showing paused status"
-                )
-                self.statistics_menu.title = "Paused"
-                self._icon_nsimage = symbol_icon("pause.circle", "Paused")
-                self._nsapp.setStatusBarIcon()
-            else:
-                logger.debug(
-                    f"In refresh_status(): Application is running, showing latency and loss"
-                )
-                loss_str = f"{(self.loss*100):.2f}%" if self.loss is not None else "---"
-                latency_str = (
-                    f"{(self.latency):.2f} ms" if self.latency is not None else "---"
-                )
-                self.statistics_menu.title = f"Loss: {loss_str}, Latency: {latency_str}"
-                display = self.settings.get("display_mode", "Dot")
-                logger.debug(f"In refresh_status(): Current display_mode: {display}")
+        if use_saved:
+            latency = self.latency
+            loss = self.loss
+        else:
+            self.latency = latency
+            self.loss = loss
+        
+        if self.settings.get("paused"):
+            logger.debug(
+                f"In refresh_status(): Application is paused, showing paused status"
+            )
+            self.statistics_menu.title = "Paused"
+            self._icon_nsimage = symbol_icon("pause.circle", "Paused")
+            self._nsapp.setStatusBarIcon()
+        else:
+            logger.debug(
+                f"In refresh_status(): Application is running, showing latency and loss"
+            )
+            loss_str = f"{(loss*100):.2f}%" if loss is not None else "---"
+            latency_str = (
+                f"{(latency):.2f} ms" if latency is not None else "---"
+            )
+            self.statistics_menu.title = f"Loss: {loss_str}, Latency: {latency_str}"
+            display = self.settings.get("display_mode", "Dot")
+            logger.debug(f"In refresh_status(): Current display_mode: {display}")
 
-                match display:
-                    case "Dot":
-                        icon, new_state = status_dot_icon(
-                            self.latency, self.loss, self._last_state
-                        )
-
-                    case "Text":
-                        icon, new_state = status_text_icon(
-                            self.latency, self.loss, self._last_state
-                        )
-                    case _:
-                        raise ValueError(
-                            f"Invalid display_mode setting: {self.settings.get('display_mode')}"
-                        )
-
-                logger.debug(
-                    f"In refresh_status(): Last state: {self._last_state}, new state: {new_state}"
-                )
-                self._last_state = new_state
-
-                if icon is not None:
-                    logger.debug(
-                        f"In refresh_status(): Updating icon for new state: {new_state}"
+            match display:
+                case "Dot":
+                    icon, new_state = status_dot_icon(
+                        latency, loss, self._last_state
                     )
-                    self._icon_nsimage = icon
-                    self._nsapp.setStatusBarIcon()
+
+                case "Text":
+                    icon, new_state = status_text_icon(
+                        latency, loss, self._last_state
+                    )
+                case _:
+                    raise ValueError(
+                        f"Invalid display_mode setting: {self.settings.get('display_mode')}"
+                    )
+
+            logger.debug(
+                f"In refresh_status(): Last state: {self._last_state}, new state: {new_state}"
+            )
+            self._last_state = new_state
+
+            if icon is not None:
+                logger.debug(
+                    f"In refresh_status(): Updating icon for new state: {new_state}"
+                )
+                self._icon_nsimage = icon
+                self._nsapp.setStatusBarIcon()
 
     @clicked("Ping targets")
     def ping_targets(self, _):
@@ -251,4 +258,4 @@ class PingrThingrApp(App):
         )
         self.set_setting("paused", not self.get_setting("paused", False))
         sender.state = self.get_setting("paused", False)
-        self.refresh_status(self)
+        self.refresh_status_(use_saved=True)


### PR DESCRIPTION
Previous menu updates were handled by a periodic rumps.Timer(), since directly updating the menuitem text from the pinger thread was not thread safe. Refactored to use pyobj methods to call the display update method from within the main app thread.