### PR TITLE
Bugfix/75 memory leak

### DIFF
--- a/pingrthingr/app.py
+++ b/pingrthingr/app.py
@@ -16,7 +16,7 @@ from .icons import symbol_icon, generate_status_icon
 from .settings import SelectableMenu, ping_target_window, SettingsManager
 from .updates import update_dialog, run_update_check
 from objc import selector as objc_selector  # type: ignore
-from Foundation import NSOperationQueue, NSBlockOperation  # type: ignore
+from Foundation import NSOperationQueue, NSBlockOperation, NSTimer, NSRunLoop  # type: ignore
 from AppKit import NSImage, NSView  # type: ignore
 
 
@@ -133,6 +133,33 @@ class PingrThingrApp(App):
         )
         NSOperationQueue.mainQueue().addOperation_(operation)
 
+    def run_in_timer(self, func: str, *args, **kwargs):
+        """Run a function in the main application thread using a Timer.
+
+        Schedules a function to be executed on the main thread using a one-shot
+        Timer, to allow arguments to be passed between threads without orphaned
+        references causing a emory leak.
+
+        Args:
+            func (callable): The function to execute on the main thread.
+            *args: Variable length argument list to pass to the function.
+            **kwargs: Arbitrary keyword arguments to pass to the function.
+        """
+
+        userdata = {"func": func, "args": args, "kwargs": kwargs}
+        logger.debug(f"Scheduling function {func} to run in app thread with args: {args} and kwargs: {kwargs}")
+
+        timer = NSTimer.timerWithTimeInterval_target_selector_userInfo_repeats_(
+            0.0, self, "_run_from_timer:", userdata, False
+        )        
+        NSRunLoop.mainRunLoop().addTimer_forMode_(timer, "NSDefaultRunLoopMode")
+
+    def _run_from_timer_(self, timer):
+        user_info = timer.userInfo()
+
+        logger.debug(f"Running function {user_info['func']} from timer with args: {user_info['args']} and kwargs: {user_info['kwargs']}")
+        getattr(self, user_info["func"])(*user_info["args"], **user_info["kwargs"])
+
     def pause_cb(self, paused: bool) -> None:
         """Callback for pause setting changes.
 
@@ -178,7 +205,9 @@ class PingrThingrApp(App):
             f"In update_statistics(): Updating statistics: loss={loss}, latency={latency}"
         )
 
-        self._run_in_app_thread(self.refresh_status_, latency, loss)
+        # self._run_in_app_thread(self.refresh_status_, latency, loss)
+
+        self.run_in_timer("refresh_status_", latency, loss)
 
     def _draw_icon(self, icon: NSImage | NSView) -> None:
         """Draw the menu bar icon.

--- a/pingrthingr/app.py
+++ b/pingrthingr/app.py
@@ -286,7 +286,7 @@ class PingrThingrApp(App):
             offset_y = (button_frame.size.height - icon_frame.size.height) / 2
             icon.setFrameOrigin_((offset_x, offset_y))
 
-    @objc_selector
+    # @objc_selector
     def refresh_status_(
         self,
         latency: float | None = None,

--- a/pingrthingr/app.py
+++ b/pingrthingr/app.py
@@ -117,24 +117,6 @@ class PingrThingrApp(App):
 
         logger.info(f"Initialized PingrThingr")
 
-    def _run_in_app_thread(self, func, *args, **kwargs):
-        """Run a function in the main application thread.
-
-        Utility method to execute a given function with arguments on the main
-        thread of the application. Useful for ensuring that UI updates and
-        other main-thread-only operations are performed safely from background
-        threads.
-
-        Args:
-            func (callable): The function to execute on the main thread.
-            *args: Variable length argument list to pass to the function.
-            **kwargs: Arbitrary keyword arguments to pass to the function.
-        """
-        operation = NSBlockOperation.blockOperationWithBlock_(
-            lambda: func(*args, **kwargs)
-        )
-        NSOperationQueue.mainQueue().addOperation_(operation)
-
     def run_in_timer(self, func: str, *args, **kwargs):
         """Run a function in the main application thread using a Timer.
 
@@ -229,17 +211,7 @@ class PingrThingrApp(App):
             f"In update_statistics(): Updating statistics: loss={loss}, latency={latency}"
         )
 
-        # self._run_in_app_thread(self.refresh_status_, latency, loss)
-
         self.run_in_timer("refresh_status_", latency, loss)
-
-        # userdata = {"latency": latency, "loss": loss, "func": "refresh_status_"}
-        # logger.debug(f"Scheduling refresh to run in app thread ")
-
-        # timer = NSTimer.timerWithTimeInterval_target_selector_userInfo_repeats_(
-        #     0.0, self, "_run_from_timer:", userdata, False
-        # )        
-        # NSRunLoop.mainRunLoop().addTimer_forMode_(timer, "NSDefaultRunLoopMode")
 
     def _draw_icon(self, icon: NSImage | NSView) -> None:
         """Draw the menu bar icon.
@@ -286,7 +258,6 @@ class PingrThingrApp(App):
             offset_y = (button_frame.size.height - icon_frame.size.height) / 2
             icon.setFrameOrigin_((offset_x, offset_y))
 
-    # @objc_selector
     def refresh_status_(
         self,
         latency: float | None = None,

--- a/pingrthingr/app.py
+++ b/pingrthingr/app.py
@@ -19,6 +19,7 @@ from objc import selector as objc_selector  # type: ignore
 from Foundation import NSOperationQueue, NSBlockOperation, NSTimer, NSRunLoop  # type: ignore
 from AppKit import NSImage, NSView  # type: ignore
 import gc
+from pickle import dumps as pickle_dumps, loads as pickle_loads  # type: ignore
 
 
 class PingrThingrApp(App):
@@ -146,9 +147,10 @@ class PingrThingrApp(App):
             *args: Variable length argument list to pass to the function.
             **kwargs: Arbitrary keyword arguments to pass to the function.
         """
+        logger.debug(f"Scheduling refresh to run {func} in app thread with args: {args} and kwargs: {kwargs}")
 
-        userdata = {"func": func, "args": args, "kwargs": kwargs}
-        logger.debug(f"Scheduling function {func} to run in app thread with args: {args} and kwargs: {kwargs}")
+        # non-scalar values in userdata seem to cause memory leaks between python and objc
+        userdata = pickle_dumps({"func": func, "args": args, "kwargs": kwargs})
 
         timer = NSTimer.timerWithTimeInterval_target_selector_userInfo_repeats_(
             0.0, self, "_run_from_timer:", userdata, False
@@ -156,10 +158,29 @@ class PingrThingrApp(App):
         NSRunLoop.mainRunLoop().addTimer_forMode_(timer, "NSDefaultRunLoopMode")
 
     def _run_from_timer_(self, timer):
-        user_info = timer.userInfo()
 
-        logger.debug(f"Running function {user_info['func']} from timer with args: {user_info['args']} and kwargs: {user_info['kwargs']}")
-        getattr(self, user_info["func"])(*user_info["args"], **user_info["kwargs"])
+        logger.debug(f"Running function from timer with userInfo: {timer.userInfo()}")
+
+        try:
+            user_info = pickle_loads(timer.userInfo())
+        except Exception as e:
+            logger.error(f"Error unpickling userInfo from timer: {e}")
+            return
+        else:
+            logger.debug(f"Successfully unpickled userInfo: {user_info}")
+
+        func=getattr(self, user_info.get('func', None))
+
+        if func is None:
+            raise KeyError(f"Function name not found in timer userInfo: {user_info}")
+        else:
+            logger.debug(f"Retrieved function '{func.__name__}' from timer userInfo")
+        
+        args=user_info.get('args', ())
+        kwargs=user_info.get('kwargs', {})
+        
+        logger.debug(f"Running function from timer: {func.__name__} with args {args} and kwargs {kwargs}")
+        func(*args, **kwargs)
 
         logger.debug(f"Total objects after running function: {len(gc.get_objects())}")
 
@@ -211,6 +232,14 @@ class PingrThingrApp(App):
         # self._run_in_app_thread(self.refresh_status_, latency, loss)
 
         self.run_in_timer("refresh_status_", latency, loss)
+
+        # userdata = {"latency": latency, "loss": loss, "func": "refresh_status_"}
+        # logger.debug(f"Scheduling refresh to run in app thread ")
+
+        # timer = NSTimer.timerWithTimeInterval_target_selector_userInfo_repeats_(
+        #     0.0, self, "_run_from_timer:", userdata, False
+        # )        
+        # NSRunLoop.mainRunLoop().addTimer_forMode_(timer, "NSDefaultRunLoopMode")
 
     def _draw_icon(self, icon: NSImage | NSView) -> None:
         """Draw the menu bar icon.

--- a/pingrthingr/app.py
+++ b/pingrthingr/app.py
@@ -421,9 +421,13 @@ class PingrThingrApp(App):
         )
 
         if new_version or not quiet:
-            self._run_in_app_thread(
-                update_dialog, new_version, __VERSION__, release_url, error
+            self.run_in_timer(
+                "_update_dialog_return", new_version, __VERSION__, release_url, error
             )
+
+    def _update_dialog_return(self, new_version: str, current_version, release_url: str, error: str) -> None:
+        update_dialog(new_version, current_version, release_url, error)
+
 
     def update_timer(self, sender) -> None:
         """Handle startup update check timer expiration.

--- a/pingrthingr/app.py
+++ b/pingrthingr/app.py
@@ -18,6 +18,7 @@ from .updates import update_dialog, run_update_check
 from objc import selector as objc_selector  # type: ignore
 from Foundation import NSOperationQueue, NSBlockOperation, NSTimer, NSRunLoop  # type: ignore
 from AppKit import NSImage, NSView  # type: ignore
+import gc
 
 
 class PingrThingrApp(App):
@@ -159,6 +160,8 @@ class PingrThingrApp(App):
 
         logger.debug(f"Running function {user_info['func']} from timer with args: {user_info['args']} and kwargs: {user_info['kwargs']}")
         getattr(self, user_info["func"])(*user_info["args"], **user_info["kwargs"])
+
+        logger.debug(f"Total objects after running function: {len(gc.get_objects())}")
 
     def pause_cb(self, paused: bool) -> None:
         """Callback for pause setting changes.

--- a/pingrthingr/app.py
+++ b/pingrthingr/app.py
@@ -15,8 +15,7 @@ from .pinger import Pinger
 from .icons import symbol_icon, generate_status_icon
 from .settings import SelectableMenu, ping_target_window, SettingsManager
 from .updates import update_dialog, run_update_check
-from objc import selector as objc_selector  # type: ignore
-from Foundation import NSOperationQueue, NSBlockOperation, NSTimer, NSRunLoop  # type: ignore
+from Foundation import NSTimer, NSRunLoop  # type: ignore
 from AppKit import NSImage, NSView  # type: ignore
 import gc
 from pickle import dumps as pickle_dumps, loads as pickle_loads  # type: ignore

--- a/tests/pingrthingr/test_app.py
+++ b/tests/pingrthingr/test_app.py
@@ -24,19 +24,29 @@ def mocked_app(mocker, tmp_path):
                 json_dump(default_settings, f)
         app = PingrThingrApp("testapp")
         mock_nsapp = mocker.MagicMock()
+        mock_run_in_timer = mocker.MagicMock()
+        def _mocked_run_in_timer(func, *args, **kwargs):
+            func = getattr(app, func)
+            func(*args, **kwargs)
+        mock_run_in_timer.side_effect = _mocked_run_in_timer
         mocker.patch.object(app, "_nsapp", mock_nsapp, create=True)
+        mocker.patch.object(app, "run_in_timer", mock_run_in_timer)
         return app, mock_pinger, mock_nsapp
 
     yield _mocked_app
 
 
-@pytest.fixture(autouse=True)
-def mocked_ns_block_operation(mocker):
-    mock_ns_block_operation = mocker.MagicMock()
-    mock_ns_operation_queue = mocker.MagicMock()
-    mocker.patch("pingrthingr.app.NSBlockOperation", mock_ns_block_operation)
-    mocker.patch("pingrthingr.app.NSOperationQueue", mock_ns_operation_queue)
-    yield mock_ns_block_operation
+# # @pytest.fixture(autouse=True)
+# # def mocked_ns_block_operation(mocker):
+# #     mock_ns_block_operation = mocker.MagicMock()
+# #     mock_ns_operation_queue = mocker.MagicMock()
+# #     mocker.patch("pingrthingr.app.NSBlockOperation", mock_ns_block_operation)
+# #     mocker.patch("pingrthingr.app.NSOperationQueue", mock_ns_operation_queue)
+# #     yield mock_ns_block_operation
+
+
+#     mocker.patch.object(PingrThingrApp, "run_in_timer", _mocked_run_in_timer)
+#     yield
 
 
 class TestPingrThingrAppInitialization:
@@ -57,17 +67,11 @@ class TestPingrThingrAppInitialization:
 
 
 class TestPingUpdates:
-    def test_ping_response_updates(self, mocked_app, mocked_ns_block_operation):
+    def test_ping_response_updates(self, mocked_app):
         app, _, mocked_nsapp = mocked_app()
 
         # Simulate a ping response and check if statistics are updated
         app.update_statistics(latency=100, loss=0)
-        assert (
-            mocked_ns_block_operation.blockOperationWithBlock_.call_count == 1
-        ), "NSBlockOperation should be created to update statistics"
-        mocked_ns_block_operation.blockOperationWithBlock_.call_args[0][
-            0
-        ]()  # Call the block to execute the statistics update
         assert app.latency == 100, "Latency should be updated to 100"
         assert app.loss == 0, "Loss should be updated to 0"
         assert (
@@ -77,27 +81,15 @@ class TestPingUpdates:
             mocked_nsapp.setStatusBarIcon.called
         ), "NSApp.setMenuBarIcon should be called to update the icon"
 
-    def test_no_update_when_same(self, mocked_app, mocked_ns_block_operation):
+    def test_ping_response_no_update_when_same(self, mocked_app):
         app, _, mocked_nsapp = mocked_app()
         mocked_nsapp.setStatusBarIcon.reset_mock()  # Reset mock call count
         app.update_statistics(latency=100, loss=0)
-        assert (
-            mocked_ns_block_operation.blockOperationWithBlock_.call_count == 1
-        ), "NSBlockOperation should be created to update statistics"
-        mocked_ns_block_operation.blockOperationWithBlock_.call_args[0][
-            0
-        ]()  # Call the block to execute the statistics update
         assert (
             mocked_nsapp.setStatusBarIcon.call_count == 1
         ), "NSApp.setMenuBarIcon should be called to update the icon"
 
         app.update_statistics(latency=100, loss=0)
-        assert (
-            mocked_ns_block_operation.blockOperationWithBlock_.call_count == 2
-        ), "NSBlockOperation should be created to update statistics"
-        mocked_ns_block_operation.blockOperationWithBlock_.call_args[0][
-            0
-        ]()  # Call the block to execute the statistics update
         assert (
             mocked_nsapp.setStatusBarIcon.call_count == 1
         ), "NSApp.setMenuBarIcon should not have been called again"
@@ -199,8 +191,6 @@ class TestCheckForUpdates:
         mocker.patch("pingrthingr.app.run_update_check", mocked_update)
         mocked_dialog = mocker.MagicMock()
         mocker.patch("pingrthingr.app.update_dialog", mocked_dialog)
-        mocked_runner = mocker.MagicMock()
-        mocker.patch.object(app, "_run_in_app_thread", mocked_runner)
         mocker.patch("pingrthingr.app.__VERSION__", "v0.2.0")
 
         # Check update invocation via menu
@@ -215,9 +205,9 @@ class TestCheckForUpdates:
         app.check_for_updates_return("v1.0.0", "https://example.com/release", "", True)
         assert app.check_for_updates_menu.callback == app.check_for_updates
         assert app.check_for_updates_menu.title == "Check for updates..."
-        assert mocked_runner.called
-        mocked_runner.assert_called_once_with(
-            mocked_dialog, "v1.0.0", "v0.2.0", "https://example.com/release", ""
+        assert mocked_dialog.called
+        mocked_dialog.assert_called_once_with(
+            "v1.0.0", "v0.2.0", "https://example.com/release", ""
         )
 
         # Check update invocation via timer
@@ -233,20 +223,18 @@ class TestCheckForUpdates:
         app, _, _ = mocked_app()
         mocked_dialog = mocker.MagicMock()
         mocker.patch("pingrthingr.app.update_dialog", mocked_dialog)
-        mocked_runner = mocker.MagicMock()
-        mocker.patch.object(app, "_run_in_app_thread", mocked_runner)
 
         # Not quiet, should call runner to display results
         app.check_for_updates_return("", "", "v0.4.0 is the latest version.", False)
-        mocked_runner.assert_called_once_with(
-            mocked_dialog, "", "v0.4.0", "", "v0.4.0 is the latest version."
+        mocked_dialog.assert_called_once_with(
+            "", "v0.4.0", "", "v0.4.0 is the latest version."
         )
 
         # Quiet, should not call runner
-        mocked_runner.reset_mock()
+        mocked_dialog.reset_mock()
         app.check_for_updates_return("", "", "v0.4.0 is the latest version.", True)
         assert (
-            not mocked_runner.called
+            not mocked_dialog.called
         ), "Runner should not be called when quiet is True and no new version"
 
     def test_check_for_updates_on_startup_enabled(self, mocked_app):


### PR DESCRIPTION
Fixes #75 

Memory leak was related to lack of garbage collection passing parameters from a function in a calling thread to a task scheduled in objc main event loop. 

This patch replaces the NSBlockOperation-based approach with a one-shot NSTimer. 

A leak was still discovered when passing lists, tuples, or nested dicts as userdata to the NSTimer. The new run_in_timer method puts the target function and any arguments into a dict and pickles it before passing it into NSTimer. Note that this means that lambdas, pyobc objects, and nested functions/classes can not be passed in this way (hence passing the target function by name). 